### PR TITLE
Move ruff configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,9 @@ Issues = "https://github.com/ivanovmg/flake8-spm/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.format]
+quote-style = "single"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,0 @@
-line-length = 79
-
-[format]
-quote-style = "single"


### PR DESCRIPTION
This PR moves ruff linter and formatter configuration
from `ruff.toml` into `pyproject.toml`.

Closes #10 